### PR TITLE
Switch email delivery to SendGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # your-money-personality
+
+## Email delivery configuration
+
+The application now sends transactional email through [SendGrid](https://sendgrid.com/).
+
+### Required environment variables
+
+Set the following variable in your deployment environment (for example, in Vercel's
+Project Settings → Environment Variables):
+
+| Name | Description |
+| --- | --- |
+| `SENDGRID_API_KEY` | API key with permission to send mail via SendGrid. |
+
+After adding or updating the variable, redeploy the project so that the new value is
+picked up by the serverless email endpoint at `api/send-email.js`.
+
+### Customizing the sender and email content
+
+Transactional email bodies are generated inside
+`src/services/emailService.ts`, where you can adjust copy, styling, or the
+default `from` address (`Money Personality <notifications@yourmoneypersonality.com>`).
+Make sure any sender address you use has been verified within your SendGrid
+account (either via domain authentication or a single sender). All HTML content is
+passed directly to SendGrid in the API request, so you can modify it in code without
+needing SendGrid templates unless you prefer to manage them there.

--- a/api/send-email.js
+++ b/api/send-email.js
@@ -1,4 +1,62 @@
-const RESEND_API_KEY = 're_2JwkQ3uD_GY9yh4jdoVgjd7eM4imMWRc4';
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+
+function parseAddress(address) {
+  if (!address) {
+    return null;
+  }
+
+  if (typeof address === 'string') {
+    const trimmed = address.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const match = trimmed.match(/^(.*)<(.+)>$/);
+
+    if (match) {
+      const name = match[1].trim().replace(/^"|"$/g, '');
+      const email = match[2].trim();
+
+      if (!email) {
+        return null;
+      }
+
+      return name ? { email, name } : { email };
+    }
+
+    return { email: trimmed };
+  }
+
+  if (typeof address === 'object' && address !== null) {
+    const email = typeof address.email === 'string' ? address.email.trim() : '';
+
+    if (!email) {
+      return null;
+    }
+
+    const formatted = { email };
+
+    if (address.name) {
+      formatted.name = String(address.name).trim();
+    }
+
+    return formatted;
+  }
+
+  return null;
+}
+
+function parseRecipients(recipients) {
+  if (!Array.isArray(recipients)) {
+    const single = parseAddress(recipients);
+    return single ? [single] : [];
+  }
+
+  return recipients
+    .map(parseAddress)
+    .filter((value) => value && value.email);
+}
 
 export default async function handler(req, res) {
   // Enable CORS
@@ -18,31 +76,72 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { from, to, subject, html } = req.body;
+    const apiKey = process.env.SENDGRID_API_KEY || SENDGRID_API_KEY;
 
-    const response = await fetch('https://api.resend.com/emails', {
+    if (!apiKey) {
+      res.status(500).json({ error: 'SendGrid API key is not configured' });
+      return;
+    }
+
+    const { from, to, subject, html } = req.body || {};
+
+    const fromAddress = parseAddress(from);
+    const toAddresses = parseRecipients(to);
+
+    if (!fromAddress) {
+      res.status(400).json({ error: 'Missing or invalid "from" address' });
+      return;
+    }
+
+    if (!toAddresses.length) {
+      res.status(400).json({ error: 'At least one valid recipient is required' });
+      return;
+    }
+
+    if (!subject) {
+      res.status(400).json({ error: 'Email subject is required' });
+      return;
+    }
+
+    if (!html) {
+      res.status(400).json({ error: 'Email HTML content is required' });
+      return;
+    }
+
+    const payload = {
+      personalizations: [
+        {
+          to: toAddresses,
+          subject,
+        },
+      ],
+      from: fromAddress,
+      subject,
+      content: [
+        {
+          type: 'text/html',
+          value: html,
+        },
+      ],
+    };
+
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${RESEND_API_KEY}`,
+        Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        from,
-        to,
-        subject,
-        html,
-      }),
+      body: JSON.stringify(payload),
     });
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('Resend error:', response.status, errorText);
+      console.error('SendGrid error:', response.status, errorText);
       res.status(response.status).json({ error: errorText });
       return;
     }
 
-    const data = await response.json();
-    res.status(200).json(data);
+    res.status(200).json({ message: 'Email accepted by SendGrid' });
   } catch (error) {
     console.error('Email sending error:', error);
     res.status(500).json({ error: 'Internal server error' });

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,5 +1,7 @@
 import { CompatibilityInsights, EmailNotification } from '../types';
 
+const DEFAULT_FROM_ADDRESS = 'Money Personality <notifications@yourmoneypersonality.com>';
+
 export class EmailService {
   static async sendAssessmentInvitation(
     advisorName: string,
@@ -17,7 +19,7 @@ export class EmailService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          from: 'Money Personality <onboarding@resend.dev>',
+          from: DEFAULT_FROM_ADDRESS,
           to: [clientEmail],
           subject: `${advisorName} is asking you to discover your Money Personality!`,
           html: `
@@ -64,7 +66,6 @@ export class EmailService {
         return false;
       }
 
-      const data = await response.json();
       return true;
     } catch (error) {
       console.error('Error sending assessment invitation:', error);
@@ -87,7 +88,7 @@ export class EmailService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          from: 'Money Personality <onboarding@resend.dev>',
+          from: DEFAULT_FROM_ADDRESS,
           to: [advisorEmail],
           subject: `Money Personality Assessment Completed${clientName ? ` - ${clientName}` : ''}`,
           html: `
@@ -136,7 +137,6 @@ export class EmailService {
         return false;
       }
 
-      const data = await response.json();
       return true;
     } catch (error) {
       console.error('Error sending completion notification:', error);
@@ -159,7 +159,7 @@ export class EmailService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          from: 'Money Personality <onboarding@resend.dev>',
+          from: DEFAULT_FROM_ADDRESS,
           to: [recipientEmail],
           subject: `${sharerName} invited you to discover your Money Personality`,
           html: `
@@ -202,7 +202,6 @@ export class EmailService {
         return false;
       }
 
-      await response.json();
       return true;
     } catch (error) {
       console.error('Error sending friend assessment invitation:', error);
@@ -226,7 +225,7 @@ export class EmailService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          from: 'Money Personality <onboarding@resend.dev>',
+          from: DEFAULT_FROM_ADDRESS,
           to: [sharerEmail],
           subject: `${participantEmail} finished the Money Personality assessment!`,
           html: `
@@ -271,7 +270,6 @@ export class EmailService {
         return false;
       }
 
-      await response.json();
       return true;
     } catch (error) {
       console.error('Error sending friend completion notification:', error);


### PR DESCRIPTION
## Summary
- replace the Resend HTTP call with a SendGrid v3 Mail Send request that accepts dynamic payloads
- update the in-app email service to use a SendGrid-compatible default sender address and avoid parsing response bodies
- document the SENDGRID_API_KEY environment variable and how to customize the outbound email content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c85be3685883269d90041a3827e8d7