### PR TITLE
Fix advisor assessment persistence across sessions

### DIFF
--- a/src/pages/AdvisorDashboard.tsx
+++ b/src/pages/AdvisorDashboard.tsx
@@ -62,7 +62,7 @@ export default function AdvisorDashboard() {
 
       try {
         const [dbAssessments, dbResults] = await Promise.all([
-          AssessmentService.getAssessmentsForAdvisorFromDatabase(currentAdvisorEmail),
+          AssessmentService.getAssessmentsForAdvisorFromDatabase(currentAdvisorEmail, currentAdvisorName),
           AssessmentService.getUnlockedAssessmentResultsForAdvisor(currentAdvisorEmail),
         ]);
 


### PR DESCRIPTION
## Summary
- normalize advisor profiles so the authenticated email is always stored and cached
- ensure new shares use the canonical advisor email and backfill legacy assessments missing an email
- refresh the dashboard fetch to supply advisor context and pick up backfilled assessments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1993d29488326a4cd887b4ab7b7b5