### PR TITLE
Restrict AI summary visibility to advisors

### DIFF
--- a/src/pages/Assessment.tsx
+++ b/src/pages/Assessment.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import AssessmentCard from '../components/AssessmentCard';
 import { calculateProfile } from '../utils/profileCalculator';
-import { generateAdvisorSummary } from '../services/aiService';
 import { AssessmentService } from '../services/assessmentService';
 import { Brain, Sparkles } from 'lucide-react';
 import questionsData from '../data/questions.json';
@@ -108,14 +107,9 @@ export default function Assessment() {
           console.log('No advisor or share ID - individual assessment');
         }
 
-        // Generate advisor summary for non-advisor assessments
-        let advisorSummary = '';
+        // Clear any previously stored advisor summary - clients shouldn't keep AI summaries locally
         if (!advisorAssessmentId && !friendAssessmentId) {
-          console.log('Generating AI advisor summary...');
-          advisorSummary = await generateAdvisorSummary(profile, answers);
-          if (advisorSummary) {
-            localStorage.setItem('advisorSummary', advisorSummary);
-          }
+          localStorage.removeItem('advisorSummary');
         }
         
         // Small delay to ensure storage events fire

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -114,19 +114,18 @@ export default function Dashboard() {
         // Load user's own profile
         const storedProfile = localStorage.getItem('userProfile');
         const storedAnswers = localStorage.getItem('assessmentAnswers');
-        const storedSummary = localStorage.getItem('advisorSummary');
-        
+
         if (storedProfile) {
           setProfile(JSON.parse(storedProfile));
         }
-        
+
         if (storedAnswers) {
           setAssessmentAnswers(JSON.parse(storedAnswers));
         }
-        
-        if (storedSummary) {
-          setAdvisorSummary(storedSummary);
-        }
+
+        // Ensure any locally stored advisor summaries are cleared for client views
+        localStorage.removeItem('advisorSummary');
+        setAdvisorSummary('');
 
         // Load friend assessments
         const shares = AssessmentService.getFriendAssessmentsForUser();
@@ -416,15 +415,13 @@ export default function Dashboard() {
         </div>
 
         {/* AI Advisor Summary - Only show for advisor view or individual assessments */}
-        {advisorSummary && (
+        {isAdvisorView && advisorSummary && (
           <div className="modern-card">
             <div className="flex items-center space-x-3 mb-6">
               <div className="w-10 h-10 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
                 <Sparkles className="w-5 h-5 text-white" />
               </div>
-              <h2 className="text-2xl font-bold text-gray-900">
-                {isAdvisorView ? 'Advisor Insights' : 'AI Advisor Summary'}
-              </h2>
+              <h2 className="text-2xl font-bold text-gray-900">Advisor Insights</h2>
             </div>
             <div className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-xl p-6 border border-purple-100">
               {renderAdvisorSummary(advisorSummary)}


### PR DESCRIPTION
## Summary
- stop generating and persisting the AI advisor summary when a client completes an individual assessment
- ensure dashboards without an advisor context clear any stored summary and hide the advisor insights section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d19e4382a0832699e5f259c80e4049