### PR TITLE
Surface compatibility share link and add advisor logout

### DIFF
--- a/src/pages/AdvisorLogin.tsx
+++ b/src/pages/AdvisorLogin.tsx
@@ -260,12 +260,6 @@ export default function AdvisorLogin() {
               </div>
             )}
 
-            <div className="mt-4 p-4 bg-blue-50 rounded-lg">
-              <p className="text-blue-800 text-sm">
-                <strong>Demo Account:</strong> For testing, you can use email <code>test@advisor.com</code> with password <code>password123</code>
-              </p>
-            </div>
-
             <div className="mt-4 p-4 bg-amber-50 rounded-lg">
               <p className="text-amber-800 text-sm">
                 <strong>Note:</strong> You may need to confirm your email after signup. Check your inbox and click the confirmation link, then return here to login.

--- a/src/pages/AdvisorWelcome.tsx
+++ b/src/pages/AdvisorWelcome.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { Brain, TrendingUp, MessageCircle, ArrowRight, Users, Mail, CheckCircle, BarChart3 } from 'lucide-react';
+import { Brain, TrendingUp, MessageCircle, ArrowRight, Users, Mail, CheckCircle, BarChart3, LogOut } from 'lucide-react';
 import { AssessmentService } from '../services/assessmentService';
 
 export default function AdvisorWelcome() {
-  const { advisor } = useAuth();
+  const { advisor, logout } = useAuth();
+  const navigate = useNavigate();
   const [isSharing, setIsSharing] = useState(false);
   const [shareSuccess, setShareSuccess] = useState(false);
   const [shareError, setShareError] = useState('');
@@ -37,6 +38,11 @@ export default function AdvisorWelcome() {
       ...formData,
       [e.target.name]: e.target.value
     });
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/advisor/login');
   };
 
   const handleShareAssessment = async (e: React.FormEvent) => {
@@ -76,9 +82,9 @@ export default function AdvisorWelcome() {
       <div className="bg-primary-600 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex justify-between items-center">
-            <img 
-              src="https://media-cdn.igrad.com/IMAGE/Logos/White/iGradEnrich.png" 
-              alt="iGrad Enrich" 
+            <img
+              src="https://media-cdn.igrad.com/IMAGE/Logos/White/iGradEnrich.png"
+              alt="iGrad Enrich"
               className="h-8 w-auto"
             />
             <div className="flex items-center space-x-4">
@@ -94,6 +100,14 @@ export default function AdvisorWelcome() {
               >
                 For Individuals
               </Link>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="inline-flex items-center space-x-2 text-primary-100 hover:text-white transition-colors duration-200 text-sm font-medium"
+              >
+                <LogOut className="w-4 h-4" />
+                <span>Logout</span>
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,6 +24,8 @@ export default function Dashboard() {
   const [isSharing, setIsSharing] = useState(false);
   const [shareSuccess, setShareSuccess] = useState(false);
   const [shareError, setShareError] = useState('');
+  const [shareLink, setShareLink] = useState('');
+  const [shareCopyFeedback, setShareCopyFeedback] = useState('');
   const [friendShares, setFriendShares] = useState<FriendAssessmentShare[]>([]);
   const [compatibility, setCompatibility] = useState<CompatibilityInsights | null>(null);
   const [advisorResult, setAdvisorResult] = useState<DatabaseAssessmentResult | null>(null);
@@ -124,6 +126,8 @@ export default function Dashboard() {
     setIsSharing(true);
     setShareError('');
     setShareSuccess(false);
+    setShareLink('');
+    setShareCopyFeedback('');
 
     const userName = localStorage.getItem('userName') || 'Someone';
     const userEmail = localStorage.getItem('userEmail') || '';
@@ -142,6 +146,7 @@ export default function Dashboard() {
 
     if (result.success) {
       setShareSuccess(true);
+      setShareLink(result.assessmentLink || '');
       setShareEmail('');
       setShareName('');
       setPersonalNote('');
@@ -151,6 +156,21 @@ export default function Dashboard() {
       setFriendShares(shares);
     } else {
       setShareError(result.error || 'Failed to share assessment');
+      setShareLink('');
+    }
+  };
+
+  const handleCopyShareLink = async () => {
+    if (!shareLink) return;
+
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setShareCopyFeedback('Link copied to clipboard!');
+      setTimeout(() => setShareCopyFeedback(''), 3000);
+    } catch (error) {
+      console.error('Failed to copy link:', error);
+      setShareCopyFeedback('Unable to copy automatically. Please copy the link manually.');
+      setTimeout(() => setShareCopyFeedback(''), 4000);
     }
   };
 
@@ -542,11 +562,11 @@ export default function Dashboard() {
               <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center">
                 <Share2 className="w-5 h-5 text-white" />
               </div>
-              <h2 className="text-2xl font-bold text-gray-900">Share with Partner</h2>
+              <h2 className="text-2xl font-bold text-gray-900">Share the Compatibility Quiz</h2>
             </div>
 
             <p className="text-gray-600 mb-6">
-              Invite your partner to take the assessment and discover how your money personalities work together.
+              Invite someone important in your life to explore how your money personalities complement each other.
             </p>
 
             {shareSuccess && (
@@ -555,7 +575,32 @@ export default function Dashboard() {
                   <Star className="w-5 h-5 text-green-600" />
                   <p className="text-green-800 font-medium">Assessment invitation sent successfully!</p>
                 </div>
-                <p className="text-green-700 text-sm mt-1">They'll receive an email with the assessment link.</p>
+                <p className="text-green-700 text-sm mt-1">They'll receive an email with the quiz link.</p>
+                {shareLink && (
+                  <div className="mt-4 text-left">
+                    <p className="text-sm text-green-700 mb-2">
+                      Want to share it directly? Use this link:
+                    </p>
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                      <input
+                        type="text"
+                        readOnly
+                        value={shareLink}
+                        className="flex-1 px-3 py-2 border border-green-200 rounded-lg bg-white text-sm text-gray-800"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleCopyShareLink}
+                        className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg shadow-sm transition-colors"
+                      >
+                        Copy link
+                      </button>
+                    </div>
+                    {shareCopyFeedback && (
+                      <p className="text-xs text-green-700 mt-2">{shareCopyFeedback}</p>
+                    )}
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/services/assessmentService.ts
+++ b/src/services/assessmentService.ts
@@ -63,7 +63,7 @@ export class AssessmentService {
     sharerProfile: Profile,
     personalNote?: string,
     recipientName?: string
-  ): Promise<{ success: boolean; shareId?: string; error?: string }> {
+  ): Promise<{ success: boolean; shareId?: string; assessmentLink?: string; error?: string }> {
     try {
       if (!sharerProfile) {
         return { success: false, error: 'Your profile is required before sharing the assessment.' };
@@ -103,7 +103,7 @@ export class AssessmentService {
         throw new Error('Failed to send invitation email');
       }
 
-      return { success: true, shareId };
+      return { success: true, shareId, assessmentLink };
     } catch (error) {
       console.error('Error sharing assessment with friend:', error);
       return {


### PR DESCRIPTION
## Summary
- show the generated compatibility quiz link immediately after a share and allow copying it
- neutralize the partner sharing language and remove demo account credentials from the advisor login page
- add a logout control to the advisor sharing page for authenticated users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1ae9439288326b6c6d302c0ab19eb